### PR TITLE
Fixing transform styling

### DIFF
--- a/index.svelte
+++ b/index.svelte
@@ -66,8 +66,8 @@
         flipY = -1;
         break;
       default:
-        flipX = 0;
-        flipY = 0;
+        flipX = 1;
+        flipY = 1;
         break;
     }
   }

--- a/index.svelte
+++ b/index.svelte
@@ -9,8 +9,8 @@
   export let style = "";
 
   let height = size;
-  let flipX = "0";
-  let flipY = "0";
+  let flipX = "1";
+  let flipY = "1";
 
   $: {
     switch (size) {
@@ -79,7 +79,7 @@
   {height}
   aria-hidden="true"
   role="img"
-  style={`transform: rotate(${rotate}turn scaleX(${flipX}) scaleY(${flipY}); ${style}`}>
+  style={`transform: rotate(${rotate}turn) scaleX(${flipX}) scaleY(${flipY}); ${style}`}>
 
   {#if Array.isArray(icon.icon[4])}
     <path


### PR DESCRIPTION
* The `rotate()` parens wasn't closed (which made the entire line of CSS invalid)
* applying `scaleX(0)`/`scaleY(0)` makes it shrink to nothing. `scale(1)` keeps the element without scaling.

Would greatly appreciate it if you could review, merge and release these changes to NPM :)